### PR TITLE
Adding a default cooldown for asg of 60s

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Module Input Variables
 #### Optional
 
 - `alb_listener_arn`                 - ARN of ALB listener to which target group should be registered
+- `default_cooldown`                 - The amount of time, in seconds, after a scaling activity completes before another scaling activity can start. (default: 60)
 - `max_size`                         - Maximum size of auto scaling group (default: 4)
 - `min_size`                         - Minimum size of auto scaling group (default: 2)
 - `health_check_grace_period`        - Time in seconds to wait before beginning health checks (default: 120)

--- a/main.tf
+++ b/main.tf
@@ -30,9 +30,9 @@ resource "aws_autoscaling_group" "app" {
   name                      = "tf-asg-${aws_launch_configuration.app.name}"
   max_size                  = "${var.max_size}"
   min_size                  = "${var.min_size}"
-  #desired_capacity          = "${var.desired_capacity}"
   min_elb_capacity          = "${var.min_size}"
   health_check_grace_period = "${var.health_check_grace_period}"
+  default_cooldown          = "${var.default_cooldown}"
   health_check_type         = "${var.health_check_type}"
   termination_policies      = ["OldestLaunchConfiguration", "ClosestToNextInstanceHour", "Default"]
   wait_for_capacity_timeout = "${var.wait_for_capacity_timeout}"

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,11 @@ variable "wait_for_capacity_timeout" {
   default     = "10m"
 }
 
+variable "default_cooldown" {
+  default     = "60"
+  description = "The amount of time, in seconds, after a scaling activity completes before another scaling activity can start. (default: 60)"
+}
+
 variable "asg_subnets" {
   type        = "list"
   description = "List of subnet IDs in which to create app server instances"


### PR DESCRIPTION
The standard default is 300s, which is a bit to long