### PR TITLE
Use coalesce() to reconfigure image_id variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ data "aws_vpc" "vpc" {
 }
 
 data "aws_ami" "app" {
-  count       = var.ami_id ? 0 : 1
+  count       = var.ami_id == "" ? 0 : 1
   most_recent = true
   owners      = [data.aws_caller_identity.current.account_id]
 
@@ -69,7 +69,7 @@ resource "aws_autoscaling_group" "app" {
 
 resource "aws_launch_configuration" "app" {
   name_prefix                 = "tf-lc-${data.aws_vpc.vpc.tags["Name"]}-${var.app}-"
-  image_id                    = var.ami_id ? null : data.aws_ami.app.id[0]
+  image_id                    = var.ami_id == "" ? null : data.aws_ami.app[0].id
   instance_type               = var.instance_type
   iam_instance_profile        = var.iam_instance_profile
   key_name                    = var.key_name

--- a/main.tf
+++ b/main.tf
@@ -18,12 +18,13 @@ data "aws_vpc" "vpc" {
 }
 
 data "aws_ami" "app" {
+  count       = var.ami_id ? 0 : 1
   most_recent = true
   owners      = [data.aws_caller_identity.current.account_id]
 
   filter {
-    name   = "image-id"
-    values = [var.ami_id]
+    name   = "name"
+    values = ["tomcat-webapi-312"]
   }
 }
 
@@ -68,7 +69,7 @@ resource "aws_autoscaling_group" "app" {
 
 resource "aws_launch_configuration" "app" {
   name_prefix                 = "tf-lc-${data.aws_vpc.vpc.tags["Name"]}-${var.app}-"
-  image_id                    = data.aws_ami.app.id
+  image_id                    = var.ami_id ? null : data.aws_ami.app.id[0]
   instance_type               = var.instance_type
   iam_instance_profile        = var.iam_instance_profile
   key_name                    = var.key_name

--- a/main.tf
+++ b/main.tf
@@ -23,8 +23,8 @@ data "aws_ami" "app" {
   owners      = [data.aws_caller_identity.current.account_id]
 
   filter {
-    name   = "name"
-    values = ["tomcat-webapi-312"]
+    name   = "image-id"
+    values = [var.ami_id]
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,7 +11,7 @@ output "target_group_name" {
 }
 
 output "ami_name" {
-  value = data.aws_ami.app.name
+  value = data.aws_ami.app[0].name
 }
 
 output "autoscaling_group_arn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,9 +10,9 @@ output "target_group_name" {
   value = aws_alb_target_group.app.name
 }
 
-output "ami_name" {
-  value = data.aws_ami.app[0].name
-}
+#output "ami_name" {
+#  value = data.aws_ami.app[0].name
+#}
 
 output "autoscaling_group_arn" {
   value = aws_autoscaling_group.app.arn


### PR DESCRIPTION
# Changes
- Use coalesce() to either use the existing AMI ID or the one passed from the module