### PR TITLE
Create ssm param to store ami_id

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,7 @@ data "aws_vpc" "vpc" {
 }
 
 resource "aws_ssm_parameter" "ami_id_param" {
+  count = var.ami_id != "" ? 1 : 0
   name  = "/${var.env}/webapi_ami_id"
   description = "AMI ID to be used for webapi_secondary/tertiary instances"
   type  = "String"

--- a/main.tf
+++ b/main.tf
@@ -17,13 +17,24 @@ data "aws_vpc" "vpc" {
   id = var.vpc_id
 }
 
+resource "aws_ssm_parameter" "ami_id_param" {
+  name  = "/${var.env}/webapi_ami_id"
+  description = "AMI ID to be used for webapi_secondary/tertiary instances"
+  type  = "String"
+  value = var.ami_id
+}
+
+#data "aws_ssm_parameter" "ami_id" {
+#  name = aws_ssm_parameter.ami_id_param.name
+#}
+
 data "aws_ami" "app" {
   most_recent = true
   owners      = [data.aws_caller_identity.current.account_id]
 
   filter {
     name   = "image-id"
-    values = [var.ami_id]
+    values = [coalesce(aws_ssm_parameter.ami_id_param.value, var.ami_id)]
   }
 }
 
@@ -132,4 +143,3 @@ resource "aws_security_group_rule" "app_egress" {
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.app.id
 }
-

--- a/main.tf
+++ b/main.tf
@@ -18,11 +18,11 @@ data "aws_vpc" "vpc" {
 }
 
 resource "aws_ssm_parameter" "ami_id_param" {
-  count = var.ami_id != "" ? 1 : 0
-  name  = "/${var.env}/webapi_ami_id"
+  count       = var.ami_id != "" ? 1 : 0
+  name        = "/${var.env}/webapi_ami_id"
   description = "AMI ID to be used for webapi_secondary/tertiary instances"
-  type  = "String"
-  value = var.ami_id
+  type        = "String"
+  value       = var.ami_id
 }
 
 #data "aws_ssm_parameter" "ami_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "app" {
 variable "ami_id" {
   type        = string
   description = "ID of AMI to deploy via launch configuration"
-  default = ""
+  default     = ""
 }
 
 variable "vpc_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,7 @@ variable "app" {
 variable "ami_id" {
   type        = string
   description = "ID of AMI to deploy via launch configuration"
+  default = ""
 }
 
 variable "vpc_id" {


### PR DESCRIPTION
# Changes
- Creates an `aws_ssm_parameter` to store the ami id
- `Coalesce()` is being used to fetch the ami id from already existing ssm_param
- For the first time, `coalesce()` makes use of the value passed by `ami_id`


# Note
- A data source will be used  as a next step to fetch the ssm_param value