### PR TITLE
Use ami_id variable to filter the image-id in a data source

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ data "aws_ami" "app" {
 
   filter {
     name   = "image-id"
-    values = [coalesce(aws_ssm_parameter.ami_id_param.value, var.ami_id)]
+    values = [var.ami_id]
   }
 }
 


### PR DESCRIPTION
# Issue
- Launch configuration and Auto scaling group are getting replaced due to a reference to an aws_ssm_parameter which is not created yet.

# Changes
- Filter the image_id in data source with `ami_id` variable instead of an attribute reference to aws_ssm_parameter

# Note
- After the ssm_paramter is created, the image id filter will be made to refer to the latest ssm_parameter value