### PR TITLE
Update image-id filter to refer ssm_param value

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ data "aws_ami" "app" {
 
   filter {
     name   = "image-id"
-    values = [var.ami_id]
+    values = [aws_ssm_parameter.ami_id_param.value]
   }
 }
 


### PR DESCRIPTION
# Task
- To use the latest image stored in `aws_ssm_parameter`

# Changes
- Change the image-id filter in aws_ami data source block to refer the value in `webapi_ami_id` ssm param

# Note
- Attached the missing `AWSSSMFullAcces` to the circle-ci-spike