### PR TITLE
Upgrade aws provider to 4.9.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -50,23 +50,21 @@ resource "aws_autoscaling_group" "app" {
   launch_configuration      = aws_launch_configuration.app.name
   vpc_zone_identifier       = var.asg_subnets
 
-  tags = [
-    {
-      key                 = "Name"
-      value               = "AS-${var.env}-${var.app}"
-      propagate_at_launch = true
-    },
-    {
-      key                 = "App"
-      value               = var.app
-      propagate_at_launch = true
-    },
-    {
-      key                 = "CrowdStrikeEnv"
-      value               = "production"
-      propagate_at_launch = true
-    },
-  ]
+  tag {
+    key                 = "Name"
+    value               = "AS-${var.env}-${var.app}"
+    propagate_at_launch = true
+  }
+  tag {
+    key                 = "App"
+    value               = var.app
+    propagate_at_launch = true
+  }
+  tag {
+    key                 = "CrowdStrikeEnv"
+    value               = "production"
+    propagate_at_launch = true
+  }
 
   lifecycle {
     create_before_destroy = true

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,4 +25,3 @@ output "autoscaling_group_id" {
 output "autoscaling_group_name" {
   value = aws_autoscaling_group.app.name
 }
-

--- a/providers.tf
+++ b/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.75.2"
+      version = "~> 4.9.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -144,4 +144,3 @@ variable "associate_public_ip_address" {
   description = "Associate a public IP address with app server instances"
   default     = "false"
 }
-


### PR DESCRIPTION
# Task
- Upgrade aws provider to 4.9.0

# Changes
- Removes the deprecated `tags` attribute and instead replace each tag with a `tag` block