### PR TITLE
Bump aws provider to 4.59.0 to work with ssm_param

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,10 +18,10 @@ data "aws_vpc" "vpc" {
 }
 
 resource "aws_ssm_parameter" "ami_id_param" {
-  name        = "/${var.env}/${var.app}/webapi_ami_id"
-  description = "AMI ID to be used for webapi_secondary/tertiary instances"
-  type        = "String"
-  value       = var.ami_id
+  name           = "/${var.env}/${var.app}/webapi_ami_id"
+  description    = "AMI ID to be used for webapi_secondary/tertiary instances"
+  type           = "String"
+  insecure_value = var.ami_id == "" ? var.ami_id : null
 }
 
 data "aws_ami" "app" {

--- a/providers.tf
+++ b/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.9.0"
+      version = "~> 4.59.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "app" {
 variable "ami_id" {
   type        = string
   description = "ID of AMI to deploy via launch configuration"
-  default     = null
+  default     = ""
 }
 
 variable "vpc_id" {


### PR DESCRIPTION
# Task
- Bump aws provider to 4.59.0

# Changes
- Upgrade aws provider to 4.59.0
- Change the default value of ami_id to be empty string and 
- Change the `value` attribute to `insecure_value` in aws_ssm_parameter resource which makes the ssm_param to take the previous value in the event of not passing an ami_id