### PR TITLE
Update insecure_value to be var.ami_id

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "aws_ssm_parameter" "ami_id_param" {
   name           = "/${var.env}/${var.app}/webapi_ami_id"
   description    = "AMI ID to be used for webapi_secondary/tertiary instances"
   type           = "String"
-  insecure_value = var.ami_id == "" ? var.ami_id : null
+  insecure_value = var.ami_id
 }
 
 data "aws_ami" "app" {


### PR DESCRIPTION
# Issue
- Error when deploying with a new ami_id

# Changes
- Updated the `insecure_value` to use `var.ami_id`
- When ami_id is "" produces a plan with `No Changes`
- Otherwise, deploys the instances with the provided ami_id