### PR TITLE
Reconfigure module with a sticky ami id stored in ssm

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -11,7 +11,7 @@ output "target_group_name" {
 }
 
 output "ami_name" {
-  value = data.aws_ami.app.name
+  value = aws_ssm_parameter.ami_id_param.insecure_value
 }
 
 output "autoscaling_group_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,7 @@ variable "app" {
 
 variable "ami_id" {
   type        = string
-  description = "ID of AMI to deploy via launch configuration"
+  description = "ID of AMI to deploy via launch configuration. This variable is sticky. You must populate it with a valid AMI ID the first time this module is applied. After that it is optional."
   default     = ""
 }
 


### PR DESCRIPTION
- Refactor module to handle the ami id as an insenstive value allowing terraform to properly determine the plan is noop
- Add logic to use a data lookup when ami_id is not passed and set the ssm param when it is passed
- Remove the ami data object that was getting latest by ami id - this makes no sense. Instead we put validation on the ssm param with type = aws:ec2:image