### PR TITLE
workaround issue causing inconsistant plans with ssm param object

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,7 +72,7 @@ resource "aws_autoscaling_group" "app" {
 
 resource "aws_launch_configuration" "app" {
   name_prefix                 = "tf-lc-${data.aws_vpc.vpc.tags["Name"]}-${var.app}-"
-  image_id                    = aws_ssm_parameter.ami_id_param.insecure_value
+  image_id                    = var.ami_id != "" ? var.ami_id : nonsensitive(data.aws_ssm_parameter.ami_id_param[0].value)
   instance_type               = var.instance_type
   iam_instance_profile        = var.iam_instance_profile
   key_name                    = var.key_name


### PR DESCRIPTION
## Issue

Something in the provider does not like the way I initially had this setup to wait for the ssm parameter to update and then read the value written.
```
│ Error: Provider produced inconsistent final plan
│ 
│ When expanding the plan for module.webapi-secondary.aws_launch_configuration.app to include new values learned so far during apply, provider
│ "registry.terraform.io/hashicorp/aws" produced an invalid new value for .image_id: was cty.StringVal("ami-0ce17ab92402d83fe"), but now
│ cty.StringVal("ami-0dc16de46f9fead7e").
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
╵
```

## Changes
To work around this instead we use the input variable when its not empty directly and the looked up object otherwise. The same logic that is used to set the ssm parameter.